### PR TITLE
Prevent dnsmasq startup failure - NethServer/dev#5069

### DIFF
--- a/src/lib/ks/unattended
+++ b/src/lib/ks/unattended
@@ -55,8 +55,9 @@ fi
 
 # enable dhcp on all network interfaces
 for net in `find /sys/class/net/ ! -name lo | cut -d '/' -f5`; do
-    echo "network --onboot=yes --bootproto=dhcp --device=$net" --nameserver=8.8.8.8 >>/tmp/network-include
+    echo "network --onboot=yes --bootproto=dhcp --device=$net" >>/tmp/network-include
 done
+echo "network --nameserver=8.8.8.8 --hostname=localhost.localdomain" >> /tmp/network-include
 
 # set keyboard
 if [ -z $keyboard ]; then


### PR DESCRIPTION
On first boot, after unattended installation, dhclient fails to set the
domain name correctly. Dnsmasq fails starting up on this condition.  To
workaround this issue we explicitly set the FQDN from Anaconda.

NethServer/dev#5069
