### PR TITLE
Disable firewalld service and configuration

### DIFF
--- a/src/lib/ks/interactive
+++ b/src/lib/ks/interactive
@@ -87,6 +87,7 @@ repo --name=nethserver --baseurl=file:///run/install/repo/extras
 install
 # Network information
 %include /tmp/network-include
+firewall --disable
 # System language
 lang en_US
 # SELinux configuration
@@ -124,7 +125,7 @@ rpm --import /etc/pki/rpm-gpg/*
 echo "Enable nethserver units..."
 systemctl enable nethserver-system-init
 systemctl enable nethserver-config-network
-systemctl disable NetworkManager
+systemctl disable NetworkManager firewalld
 
 echo "Disable kdump..."
 systemctl disable kdump

--- a/src/lib/ks/unattended
+++ b/src/lib/ks/unattended
@@ -100,6 +100,7 @@ repo --name=nethserver --baseurl=file:///run/install/repo/extras
 install
 # Network information
 %include /tmp/network-include
+firewall --disable
 # Root password
 rootpw --plaintext Nethesis,1234
 # System keyboard
@@ -143,7 +144,7 @@ rpm --import /etc/pki/rpm-gpg/*
 echo "Enable nethserver units..."
 systemctl enable nethserver-system-init
 systemctl enable nethserver-config-network
-systemctl disable NetworkManager
+systemctl disable NetworkManager firewalld
 
 echo "Disable kdump..."
 systemctl disable kdump


### PR DESCRIPTION
This avoid system-init event failure due to a race condition between
firewalld and shorewall that unloads netfilter modules.