### PR TITLE
Show Nethserver web interface URLs on login via /etc/issue

### DIFF
--- a/src/lib/ks/interactive
+++ b/src/lib/ks/interactive
@@ -134,6 +134,8 @@ if [ -f /etc/nethserver-release ]; then
   echo "Fix /etc/issue..."
   cp -f /etc/nethserver-release /etc/issue
   echo -e 'Kernel \\r on an \\m\n' >> /etc/issue
+  echo -e '\nTo login to NethServer please use following URL(s):\n\n' >> /etc/issue
+  ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/.*/https:\/\/&:980/' >> /etc/issue
 fi
 
 %end

--- a/src/lib/ks/interactive
+++ b/src/lib/ks/interactive
@@ -134,8 +134,9 @@ if [ -f /etc/nethserver-release ]; then
   echo "Fix /etc/issue..."
   cp -f /etc/nethserver-release /etc/issue
   echo -e 'Kernel \\r on an \\m\n' >> /etc/issue
-  echo -e '\nTo login to NethServer please use following URL(s):\n\n' >> /etc/issue
+  echo 'To login to NethServer please use following URL(s):' >> /etc/issue
   ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/.*/https:\/\/&:980/' >> /etc/issue
+  echo >> /etc/issue
 fi
 
 %end

--- a/src/lib/ks/interactive
+++ b/src/lib/ks/interactive
@@ -134,8 +134,8 @@ if [ -f /etc/nethserver-release ]; then
   echo "Fix /etc/issue..."
   cp -f /etc/nethserver-release /etc/issue
   echo -e 'Kernel \\r on an \\m\n' >> /etc/issue
-  echo 'To login to NethServer please use following URL(s):' >> /etc/issue
-  ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/.*/https:\/\/&:980/' >> /etc/issue
+  echo 'Access the web interface at the following URLs:' >> /etc/issue
+  ip -o -4 addr | tr -s ' /' $'\t' | cut -f 4 | grep -vF 127.0.0.1 | xargs -I IP -- echo https://IP:980 >> /etc/issue
   echo >> /etc/issue
 fi
 

--- a/src/lib/ks/manual
+++ b/src/lib/ks/manual
@@ -44,8 +44,9 @@ if [ -f /etc/nethserver-release ]; then
   echo "Fix /etc/issue..."
   cp -f /etc/nethserver-release /etc/issue
   echo -e 'Kernel \\r on an \\m\n' >> /etc/issue
-  echo -e '\nTo login to NethServer please use following URL(s):\n\n' >> /etc/issue
+  echo 'To login to NethServer please use following URL(s):' >> /etc/issue
   ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/.*/https:\/\/&:980/' >> /etc/issue
+  echo >> /etc/issue
 fi
 
 %end

--- a/src/lib/ks/manual
+++ b/src/lib/ks/manual
@@ -44,6 +44,8 @@ if [ -f /etc/nethserver-release ]; then
   echo "Fix /etc/issue..."
   cp -f /etc/nethserver-release /etc/issue
   echo -e 'Kernel \\r on an \\m\n' >> /etc/issue
+  echo -e '\nTo login to NethServer please use following URL(s):\n\n' >> /etc/issue
+  ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/.*/https:\/\/&:980/' >> /etc/issue
 fi
 
 %end

--- a/src/lib/ks/manual
+++ b/src/lib/ks/manual
@@ -44,8 +44,8 @@ if [ -f /etc/nethserver-release ]; then
   echo "Fix /etc/issue..."
   cp -f /etc/nethserver-release /etc/issue
   echo -e 'Kernel \\r on an \\m\n' >> /etc/issue
-  echo 'To login to NethServer please use following URL(s):' >> /etc/issue
-  ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/.*/https:\/\/&:980/' >> /etc/issue
+  echo 'Access the web interface at the following URLs:' >> /etc/issue
+  ip -o -4 addr | tr -s ' /' $'\t' | cut -f 4 | grep -vF 127.0.0.1 | xargs -I IP -- echo https://IP:980 >> /etc/issue
   echo >> /etc/issue
 fi
 

--- a/src/lib/ks/unattended
+++ b/src/lib/ks/unattended
@@ -153,6 +153,8 @@ if [ -f /etc/nethserver-release ]; then
   echo "Fix /etc/issue..."
   cp -f /etc/nethserver-release /etc/issue
   echo -e 'Kernel \\r on an \\m\n' >> /etc/issue
+  echo -e '\nTo login to NethServer please use following URL(s):\n\n' >> /etc/issue
+  ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/.*/https:\/\/&:980/' >> /etc/issue
 fi
 
 %end

--- a/src/lib/ks/unattended
+++ b/src/lib/ks/unattended
@@ -153,8 +153,8 @@ if [ -f /etc/nethserver-release ]; then
   echo "Fix /etc/issue..."
   cp -f /etc/nethserver-release /etc/issue
   echo -e 'Kernel \\r on an \\m\n' >> /etc/issue
-  echo 'To login to NethServer please use following URL(s):' >> /etc/issue
-  ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/.*/https:\/\/&:980/' >> /etc/issue
+  echo 'Access the web interface at the following URLs:' >> /etc/issue
+  ip -o -4 addr | tr -s ' /' $'\t' | cut -f 4 | grep -vF 127.0.0.1 | xargs -I IP -- echo https://IP:980 >> /etc/issue
   echo >> /etc/issue
 fi
 

--- a/src/lib/ks/unattended
+++ b/src/lib/ks/unattended
@@ -153,8 +153,9 @@ if [ -f /etc/nethserver-release ]; then
   echo "Fix /etc/issue..."
   cp -f /etc/nethserver-release /etc/issue
   echo -e 'Kernel \\r on an \\m\n' >> /etc/issue
-  echo -e '\nTo login to NethServer please use following URL(s):\n\n' >> /etc/issue
+  echo 'To login to NethServer please use following URL(s):' >> /etc/issue
   ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | sed 's/.*/https:\/\/&:980/' >> /etc/issue
+  echo >> /etc/issue
 fi
 
 %end


### PR DESCRIPTION
After first reboot after base install the login URLs should be shown. This may be helpful when using DHCP or VMs.

Feature request:
https://community.nethserver.org/t/show-nethserver-web-interface-urls-on-login-via-issue/8560